### PR TITLE
Add a single tick before fixating a Tetromino like in the original game.

### DIFF
--- a/src/main/java/tetris/Controller.java
+++ b/src/main/java/tetris/Controller.java
@@ -67,6 +67,7 @@ public class Controller {
         } else if (tetromino.top() >= grid.height() - 1) {
             gameOver();
         } else {
+            timer = new Tick(onTick);
             grid.registerTetromino(tetromino);
             dropNewTetromino();
         }


### PR DESCRIPTION
In the original Tetris game there is always a tick before a Tetromino get fixed so the player can still move the landed Tetromino during this final tick.

This fix implements this little neat present.