### PR TITLE
Set original Tetromino colors by default

### DIFF
--- a/src/main/java/tetris/GameSettingsPanel.java
+++ b/src/main/java/tetris/GameSettingsPanel.java
@@ -5,12 +5,13 @@ import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ColorPicker;
-import javafx.scene.layout.HBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
 public class GameSettingsPanel extends Application {
 
-    public static final int NUMBER_OF_COLORS = 7;
     private Scene previousScene;
     private Stage primaryStage;
 
@@ -30,15 +31,19 @@ public class GameSettingsPanel extends Application {
         initializeColorPickers();
 
         stage.setTitle("ColorPicker");
-        Scene scene = new Scene(new HBox(20), 400, 100);
-        HBox box = (HBox) scene.getRoot();
-        box.setPadding(new Insets(5,5,5,5));
+        Scene scene = new Scene(new VBox(10));
+        VBox box = (VBox) scene.getRoot();
+        box.setStyle("-fx-background-color: black");
+        box.setPadding(new Insets(20, 20, 20, 20));
 
-        for(ColorPicker colorPicker : this.colorPickers) {
-            box.getChildren().add(colorPicker   );
+        for (int i = 0; i < colorPickers.length; i++) {
+            ColorPicker colorPicker = colorPickers[i];
+            Label label = new Label(String.format("Color %1$d", i + 1));
+            label.setTextFill(Color.WHITE);
+            box.getChildren().addAll(label, colorPicker);
         }
 
-        backButton = new Button("Back");
+        backButton = new Button("Back to main menu");
         hookBackButtonEvent(backButton);
 
         box.getChildren().add(backButton);
@@ -48,9 +53,13 @@ public class GameSettingsPanel extends Application {
     }
 
     public void initializeColorPickers() {
-        for(int i = 0; i < NUMBER_OF_COLORS; i++) {
-            this.colorPickers[i] = new ColorPicker();
-        }
+        this.colorPickers[0] = new ColorPicker(Color.CYAN);
+        this.colorPickers[1] = new ColorPicker(Color.BLUE);
+        this.colorPickers[2] = new ColorPicker(Color.DARKORANGE);
+        this.colorPickers[3] = new ColorPicker(Color.YELLOW);
+        this.colorPickers[4] = new ColorPicker(Color.LIME);
+        this.colorPickers[5] = new ColorPicker(Color.PURPLE);
+        this.colorPickers[6] = new ColorPicker(Color.RED);
     }
 
     public ColorPicker[] getColorPickers() {

--- a/src/main/java/tetris/tetromino/AbstractTetromino.java
+++ b/src/main/java/tetris/tetromino/AbstractTetromino.java
@@ -23,7 +23,7 @@ public abstract class AbstractTetromino {
     /**
      * Color ID.
      */
-    private int color = 1 + (int) (Math.random() * 6);
+    private int color;
 
     /**
      * Default constructor to set Tetromino structure and position.
@@ -33,9 +33,10 @@ public abstract class AbstractTetromino {
      * @param minos
      *            Coordinates of each Mino
      */
-    public AbstractTetromino(final Coordinate position, final Coordinate[] minos) {
+    public AbstractTetromino(final Coordinate position, final Coordinate[] minos, int color) {
         this.position = position;
         this.minos = minos;
+        this.color = color;
     }
 
     /**

--- a/src/main/java/tetris/tetromino/TetrominoI.java
+++ b/src/main/java/tetris/tetromino/TetrominoI.java
@@ -7,6 +7,8 @@ public class TetrominoI extends AbstractTetromino {
     private static final Coordinate[] minos = new Coordinate[] { new Coordinate(-1, 0),
         new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(2, 0) };
 
+    private static int color = 1;
+
     /**
      * ShapeI is the figure that is dropped on the gameboard.
      * 
@@ -14,6 +16,6 @@ public class TetrominoI extends AbstractTetromino {
      *            Position of shape in grid
      */
     public TetrominoI(Coordinate position) {
-        super(position, minos);
+        super(position, minos, color);
     }
 }

--- a/src/main/java/tetris/tetromino/TetrominoJ.java
+++ b/src/main/java/tetris/tetromino/TetrominoJ.java
@@ -7,6 +7,8 @@ public class TetrominoJ extends AbstractTetromino {
     private static final Coordinate[] minos = new Coordinate[] { new Coordinate(-1, 1),
         new Coordinate(-1, 0), new Coordinate(0, 0), new Coordinate(1, 0) };
 
+    private static int color = 2;
+
     /**
      * ShapeJ is the figure that is dropped on the gameboard.
      * 
@@ -14,7 +16,7 @@ public class TetrominoJ extends AbstractTetromino {
      *            Position of shape in grid
      */
     public TetrominoJ(Coordinate position) {
-        super(position, minos);
+        super(position, minos, color);
     }
 
 }

--- a/src/main/java/tetris/tetromino/TetrominoL.java
+++ b/src/main/java/tetris/tetromino/TetrominoL.java
@@ -7,6 +7,8 @@ public class TetrominoL extends AbstractTetromino {
     private static final Coordinate[] minos = new Coordinate[] { new Coordinate(-1, 0),
         new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1) };
 
+    private static int color = 3;
+
     /**
      * ShapeL is the figure that is dropped on the gameboard.
      * 
@@ -14,6 +16,6 @@ public class TetrominoL extends AbstractTetromino {
      *            Position of shape in grid
      */
     public TetrominoL(Coordinate position) {
-        super(position, minos);
+        super(position, minos, color);
     }
 }

--- a/src/main/java/tetris/tetromino/TetrominoO.java
+++ b/src/main/java/tetris/tetromino/TetrominoO.java
@@ -7,6 +7,8 @@ public class TetrominoO extends AbstractTetromino {
     private static final Coordinate[] minos = new Coordinate[] { new Coordinate(0, 0),
         new Coordinate(0, 1), new Coordinate(1, 1), new Coordinate(1, 0) };
 
+    private static int color = 4;
+
     /**
      * ShapeO is the figure that is dropped on the gameboard.
      * 
@@ -14,7 +16,7 @@ public class TetrominoO extends AbstractTetromino {
      *            Position of shape in grid
      */
     public TetrominoO(Coordinate position) {
-        super(position, minos);
+        super(position, minos, color);
     }
 
 }

--- a/src/main/java/tetris/tetromino/TetrominoS.java
+++ b/src/main/java/tetris/tetromino/TetrominoS.java
@@ -7,6 +7,8 @@ public class TetrominoS extends AbstractTetromino {
     private static final Coordinate[] minos = new Coordinate[] { new Coordinate(-1, 0),
         new Coordinate(0, 0), new Coordinate(0, 1), new Coordinate(1, 1) };
 
+    private static int color = 5;
+
     /**
      * ShapeS is the figure that is dropped on the gameboard.
      * 
@@ -14,6 +16,6 @@ public class TetrominoS extends AbstractTetromino {
      *            Position of shape in grid
      */
     public TetrominoS(Coordinate position) {
-        super(position, minos);
+        super(position, minos, color);
     }
 }

--- a/src/main/java/tetris/tetromino/TetrominoT.java
+++ b/src/main/java/tetris/tetromino/TetrominoT.java
@@ -7,6 +7,8 @@ public class TetrominoT extends AbstractTetromino {
     private static final Coordinate[] minos = new Coordinate[] { new Coordinate(-1, 0),
         new Coordinate(0, 0), new Coordinate(0, 1), new Coordinate(1, 0) };
 
+    private static int color = 6;
+
     /**
      * ShapeT is the figure that is dropped on the gameboard.
      * 
@@ -14,6 +16,6 @@ public class TetrominoT extends AbstractTetromino {
      *            Position of shape in grid
      */
     public TetrominoT(Coordinate position) {
-        super(position, minos);
+        super(position, minos, color);
     }
 }

--- a/src/main/java/tetris/tetromino/TetrominoZ.java
+++ b/src/main/java/tetris/tetromino/TetrominoZ.java
@@ -7,6 +7,8 @@ public class TetrominoZ extends AbstractTetromino {
     private static final Coordinate[] minos = new Coordinate[] { new Coordinate(-1, 1),
         new Coordinate(0, 1), new Coordinate(0, 0), new Coordinate(1, 0) };
 
+    private static int color = 7;
+
     /**
      * ShapeZ is the figure that is dropped on the gameboard.
      * 
@@ -14,7 +16,7 @@ public class TetrominoZ extends AbstractTetromino {
      *            Position of shape in grid
      */
     public TetrominoZ(Coordinate position) {
-        super(position, minos);
+        super(position, minos, color);
     }
 
 }

--- a/src/test/java/tetris/DummyShape.java
+++ b/src/test/java/tetris/DummyShape.java
@@ -7,8 +7,10 @@ public class DummyShape extends AbstractTetromino {
     private static final Coordinate[] minos = new Coordinate[] { new Coordinate(0, 0),
         new Coordinate(0, 1), new Coordinate(0, 2), new Coordinate(1, 1) };
 
+    private static int color = 1;
+
     public DummyShape(Coordinate position) {
-        super(position, minos);
+        super(position, minos, color);
     }
 
 }


### PR DESCRIPTION
- The color pickers are by default set to the original tetromino colors.
- The color pickers are arranged below each other for a better layout.
- The back button has a label so the player can see that this button is actually the back button.
- The color panel has a black background fill to match the main menu style.

_Note:_
For now each Tetromino is assigned to a color picker. It is yet unclear which Tetromino belongs to which color picker, but this is going to be added in the future.