### PR TITLE
more if refactors

### DIFF
--- a/src/main/java/tetris/KeyBindings.java
+++ b/src/main/java/tetris/KeyBindings.java
@@ -91,26 +91,16 @@ public final class KeyBindings implements Iterable<Entry<KeyCode, Action>> {
     }
 
     public boolean equals(KeyBindings other) {
-        if (other == null) {
-            return false;
-        }
         if (other == this) {
             return true;
         }
         if (!(other instanceof KeyBindings)) {
             return false;
         }
-        KeyBindings otherObject = (KeyBindings) other;
-        if (size() == otherObject.size()) {
-            boolean result;
-            result = true;
-            for (Action action : bindings.values()) {
-                if (!getKeyCode(action).equals(otherObject.getKeyCode(action))) {
-                    result = false;
-                }
-            }
-            return result;
-        } else
-            return false;
+        boolean result = true;
+        for (Action action : bindings.values()) {
+            result &= getKeyCode(action).equals(other.getKeyCode(action));
+        }
+        return result;
     }
 }


### PR DESCRIPTION
if other is null, then !(other instanceof keybindings) so first if is redundant. replaced if in loop by boolean logic. the size of bindings is fixed since there is no way to add/remove entries so size()==other.size() was also redundant